### PR TITLE
Enables custom separator for the commit message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,27 @@
 # Enforce Pull Request Title Style Action
 
+**IMPORTANT: Most of the content of this repository is coming from https://github.com/ryanvade/enforce-pr-title-style-action**
+
 This action analyses the titles of Pull Requests to ensure they start with a Jira Issue Key.  Issue Keys are a combination of a Project Key, a hyphen, and a number designating which issue it is.  In general, Project Keys are two capital letters but Jira does allow for [custom Project Keys](https://confluence.atlassian.com/adminjiraserver/changing-the-project-key-format-938847081.html) and this issue attempts to abide by the custom format. 
 
-For example, if your project key were `AB` then the following would be allowed
+For example, if your project key were `AB` then the following would be allowed (use `:` as the separator for the commit message)
 
 ```
-AB-1  Initialize Project
+AB-1:  Initialize Project
 ```
 
 However, the following examples would not be allowed
 
 ```
-aB-1 Initialize Project
+aB-1: Initialize Project
 ```
 
 ```
-ab-1 Initialize Project
+ab-1: Initialize Project
 ```
 
 ```
-Ab 1 Initialize Project
+Ab 1: Initialize Project
 ```
 
 Valid Pull Request titles must also include a short description after the Issue Key. Therefore the following is not valid. 
@@ -36,6 +38,10 @@ By default, this action will allow any valid Issue Key so long as it *could* be 
 
 A specific Project Key to always check for. 
 
+### `commitMessageSeparator`
+
+A specific separator to split the ticket and the commit message
+
 ## Example Usage
 
 ```
@@ -50,4 +56,5 @@ A specific Project Key to always check for.
   uses: ryanvade/enforce-pr-title-style-action@v1
   with:
     projectKey: AB
+    commitMessageSeparator: ":"
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@
 
 This action analyses the titles of Pull Requests to ensure they start with a Jira Issue Key.  Issue Keys are a combination of a Project Key, a hyphen, and a number designating which issue it is.  In general, Project Keys are two capital letters but Jira does allow for [custom Project Keys](https://confluence.atlassian.com/adminjiraserver/changing-the-project-key-format-938847081.html) and this issue attempts to abide by the custom format. 
 
-For example, if your project key were `AB` then the following would be allowed (use `:` as the separator for the commit message)
+For example, if your project key were `AB` then the following would be allowed (the default separator is an empty space):
+
+```
+AB-1  Initialize Project
+```
+
+If your custom separator is `:` then the following would be allowed:
 
 ```
 AB-1:  Initialize Project
@@ -13,15 +19,15 @@ AB-1:  Initialize Project
 However, the following examples would not be allowed
 
 ```
-aB-1: Initialize Project
+aB-1 Initialize Project
 ```
 
 ```
-ab-1: Initialize Project
+ab-1 Initialize Project
 ```
 
 ```
-Ab 1: Initialize Project
+Ab 1 Initialize Project
 ```
 
 Valid Pull Request titles must also include a short description after the Issue Key. Therefore the following is not valid. 

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -28,7 +28,8 @@ describe("index", () => {
 
     describe("getRegex", () => {
         const name = "projectKey";
-        it("gets the default when no project key is provided", () => {
+        const separator = "commitMessageSeparator";
+        it("gets the default project key (all) when no project key is provided", () => {
             process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] = "";
             const regex = getRegex();
             let defaultRegex = /(?<=^|[a-z]\-|[\s\p{Punct}&&[^\-]])([A-Z][A-Z0-9_]*-\d+)(?![^\W_])(\s)+(.)+/;
@@ -46,6 +47,20 @@ describe("index", () => {
         it("throws an exception if the provided project key is not valid", () => {
             process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] = "aB";
             expect(getRegex).toThrowError("Project Key  \"aB\" is invalid");
+        });
+
+        it("gets the default separator when no project key is provided", () => {
+            const regex = getRegex();
+            let defaultRegex = /(?<=^|[a-z]\-|[\s\p{Punct}&&[^\-]])([A-Z][A-Z0-9_]*-\d+)(?![^\W_])(\s)+(.)+/;
+            expect(regex).toEqual(defaultRegex);
+            expect(regex.test("PR-4 this is valid")).toBe(true);
+        });
+
+        it("uses a custom separator if it exists", () => {
+            process.env[`INPUT_${separator.replace(/ /g, '_').toUpperCase()}`] = ":";
+            const regex = getRegex();
+            expect(regex).toEqual(new RegExp(`(^AB-){1}(\\d)+(:)+(.)+`));
+            expect(regex.test("AB-43: stuff and things")).toBe(true);
         });
     });
 });

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,11 @@
-name: Enforce Pull Request Title includes Jira Issue Key
-description: Check that a PR title starts with a Jira Issue Key
+name: Enforce Pull Request Title includes Jira Issue Key and Custom Message Separator
+description: Check that a PR title starts with a Jira Issue Key and Custom Message Separator
 inputs:
   projectKey:
     description: 'A specific Jira Project Key that must be included.'
+    required: false
+  commitMessageSeparator:
+    description: 'A specific commit message separator must be included.'
     required: false
 runs:
   using: node12

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,19 +5,20 @@
   "requires": true,
   "dependencies": {
     "@actions/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
       "requires": {
-        "@actions/http-client": "^1.0.11"
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
       },
       "dependencies": {
         "@actions/http-client": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
-          "integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+          "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
           "requires": {
-            "tunnel": "0.0.6"
+            "tunnel": "^0.0.6"
           }
         }
       }
@@ -4358,9 +4359,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -5797,8 +5798,7 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "optional": true
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/ryanvade/enforce-pr-title-style-action#readme",
   "dependencies": {
-    "@actions/core": "^1.6.0",
+    "@actions/core": "^1.9.1",
     "@actions/github": "^4.0.0",
     "@octokit/webhooks": "^7.24.3",
     "@types/jest": "^26.0.24",

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,16 +25,25 @@ async function run() {
 }
 
 export function getRegex() {
-    let regex = /(?<=^|[a-z]\-|[\s\p{Punct}&&[^\-]])([A-Z][A-Z0-9_]*-\d+)(?![^\W_])(\s)+(.)+/;
+    const commitMessageSeparatorByInput = core.getInput("commitMessageSeparator", { required: false });
+    const commitMessageSeparator = isValidInput(commitMessageSeparatorByInput) ? commitMessageSeparatorByInput : '\s'
+    let regex = new RegExp(`/(?<=^|[a-z]\-|[\s\p{Punct}&&[^\-]])([A-Z][A-Z0-9_]*-\d+)(?![^\W_])(${commitMessageSeparator})+(.)+/`);
     const projectKey = core.getInput("projectKey", { required: false });
-    if (projectKey && projectKey !== "") {
+    if (isValidInput(projectKey)) {
         core.debug(`Project Key ${projectKey}`);
         if (!/(?<=^|[a-z]\-|[\s\p{Punct}&&[^\-]])([A-Z][A-Z0-9_]*)/.test(projectKey)) {
             throw new Error(`Project Key  "${projectKey}" is invalid`)
         }
-        regex = new RegExp(`(^${projectKey}-){1}(\\d)+(\\s)+(.)+`);
+        regex = new RegExp(`(^${projectKey}-){1}(\\d)+(${commitMessageSeparator})+(.)+`);
     }
     return regex;
+}
+
+export function isValidInput(input: string) {
+    if (input && input !== "") {
+        return true
+    }
+    return false
 }
 
 export function getPullRequestTitle() {


### PR DESCRIPTION
**Context:** In our organisation, we do use `:` as a separator between the ticket and the commit message. Thinking this through, I thought it might be a good addition to accept a custom separator rather than just an empty space.

**Solution:** We have released an action on our side mainly based on this one [here](https://github.com/marketplace/actions/enforce-pull-request-title-includes-jira-issue-key-and-custom-message-separator). However, this is just to unblock ourselves for today, if we could include it here, we'll remove it to of course use this one. 