### PR TITLE
Now supporting `:`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,8 @@ export function getRegex() {
         if (!/(?<=^|[a-z]\-|[\s\p{Punct}&&[^\-]])([A-Z][A-Z0-9_]*)/.test(projectKey)) {
             throw new Error(`Project Key  "${projectKey}" is invalid`)
         }
-        regex = new RegExp(`(^${projectKey}-){1}(\\d)+(\\s)+(.)+`);
+        regex = new RegExp(`(^${projectKey}-){1}(\\d+):?(\\s+)(.+)`);
+        
     }
     return regex;
 }


### PR DESCRIPTION
Until now, the only supported values were ones where there is the ticket, a space, and a description. Many places work with `:` after the ticket value, i.e. `AB-123: Description` This is now possible while also allowing the space option (`AB-123 Description` will work too!)

Also, some cleanup for the groups, now the _one or more_ quantifier is inside the match group for cleaner matching.